### PR TITLE
Enable 3D RenderTexture to be used as volume

### DIFF
--- a/Assets/VolumeRendering/Scripts/VolumeRendering.cs
+++ b/Assets/VolumeRendering/Scripts/VolumeRendering.cs
@@ -24,16 +24,16 @@ namespace VolumeRendering
         [Range(0f, 1f)] public float sliceYMin = 0.0f, sliceYMax = 1.0f;
         [Range(0f, 1f)] public float sliceZMin = 0.0f, sliceZMax = 1.0f;
 
-        [SerializeField] protected Texture3D volume;
+        public Texture volume;
 
         protected void Start () {
             material = new Material(shader);
             GetComponent<MeshFilter>().sharedMesh = Build();
             GetComponent<MeshRenderer>().sharedMaterial = material;
-            material.SetTexture("_Volume", volume);
         }
         
         protected void Update () {
+            material.SetTexture("_Volume", volume);
             material.SetColor("_Color", color);
             material.SetFloat("_Threshold", threshold);
             material.SetFloat("_Intensity", intensity);


### PR DESCRIPTION
+ Change `volume` type from `Texture3D` to `Texture`.
+ Make `volume` publicly accessible from other scripts.
+ Enable ability to update `volume` data in realtime.

Example: `RenderTexture` with 3D dimension generated from a pixel shader
![RenderTexture with 3D dimension](https://user-images.githubusercontent.com/8206622/39239238-7a2d3352-48aa-11e8-9a5f-17fba092779c.PNG)

